### PR TITLE
Renamed ecomapper to blurp in .jsons

### DIFF
--- a/blurp-app/package-lock.json
+++ b/blurp-app/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ecomapper-app",
+  "name": "blurp-app",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ecomapper-app",
+      "name": "blurp-app",
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",

--- a/blurp-app/package.json
+++ b/blurp-app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ecomapper-app",
+  "name": "blurp-app",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
.json package names now point to 'blurp'