### PR TITLE
Major sidebar modifications

### DIFF
--- a/blurp-app/src/styles/tailwind.css
+++ b/blurp-app/src/styles/tailwind.css
@@ -68,19 +68,11 @@
   }
 
   .data-sidebar {
-    @apply absolute right-[40px] my-[100px] h-[400px] w-[260px] p-0;
+    @apply absolute w-full h-full bg-gray-200 border-2 border-gray-400 border-r-0 rounded-l-xl pointer-events-auto grid justify-items-center duration-100;
   }
 
-  .data-sidebar-tab {
-    @apply bg-fuchsia-750 absolute mt-[50px] flex h-[60px] w-[15px] items-center rounded-l-md hover:cursor-pointer;
-  }
-
-  .data-sidebar-tab-arrow {
-    @apply h-full w-full text-gray-200 dark:text-gray-200;
-  }
-
-  .data-sidebar-background {
-    @apply absolute mr-0 ml-[15px] flex h-full w-[245px] rounded-l-xl border-2 border-r-0 border-gray-400 bg-gray-200 p-0;
+  .data-sidebar-frame {
+    @apply absolute right-[40px] w-[260px] h-[400px] my-[100px] overflow-hidden pointer-events-none;
   }
 
   .textbox-sidebar {


### PR DESCRIPTION
Changes:
+ The data sidebar expand/collapse is now animated (slides out).
+ Sidebar now slides within a div instead of on the page (no more scroll bars).
+ Sidebar now disappears when the user clicks away from the sidebar.
+ Fixes the issue of having to double-click on a node for the sidebar to expand.
+ Most of the code is rewritten (had to do it for the above), although it's a lot cleaner and should be easier to follow.