### PR TITLE
Resolves #62: Confirm delete UI

### DIFF
--- a/blurp-app/src/components/confirm_delete_form.jsx
+++ b/blurp-app/src/components/confirm_delete_form.jsx
@@ -1,0 +1,67 @@
+import { useState, useRef, useEffect } from "react";
+
+function ConfirmDeleteForm (props) {
+
+  const HIDDEN_FORM_CLASS = 'confirm-delete-form hidden';
+  const VISIBLE_FORM_CLASS = 'confirm-delete-form';
+  const HIDDEN_MSG_CLASS = 'obj-deleted-msg opacity-0';
+  const VISIBLE_MSG_CLASS = 'obj-deleted-msg';
+
+  const [formClass, setFormClass] = useState(VISIBLE_FORM_CLASS);
+  const [objDeletedMsgClass, setObjDeletedMsgClass] = useState(HIDDEN_MSG_CLASS);
+  const form_ref = useRef(null);
+
+  function hideForm() {
+    setFormClass(HIDDEN_FORM_CLASS);
+  }
+  function showForm() {
+    setFormClass(VISIBLE_FORM_CLASS);
+  }
+  function delete_clicked() {
+    hideForm();
+    show_deleted_message();
+  }
+  function show_deleted_message() {
+    setObjDeletedMsgClass(VISIBLE_MSG_CLASS);
+    setTimeout(hide_deleted_message, 1500);
+  }
+  function hide_deleted_message() {
+    setObjDeletedMsgClass(HIDDEN_MSG_CLASS);
+  }
+
+  useEffect(() => {
+    // Collapse toolbar if the click was outside the toolbar or (...) button.
+    const handleClickOutside = (event) => {
+      if(form_ref.current && !form_ref.current.contains(event.target)) {
+        hideForm && hideForm();
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside, true);
+    };
+  }, [hideForm]);
+
+  return (
+    <>
+      <div className={formClass} ref={form_ref}>
+        <div className='absolute flex w-full mt-[10px] justify-center'>
+        <p><b>Are you sure you want to delete this object?</b></p>
+        </div>
+        <div className='absolute flex w-full mt-[45px] justify-center'>
+        <button className="confirm-delete-btn-yes" onClick={delete_clicked}>
+          <b>Yes, delete</b>
+        </button>
+        <button className="confirm-delete-btn-no" onClick={hideForm}>
+          <b>Cancel</b>
+        </button>
+        </div>
+      </div>
+      <div className={objDeletedMsgClass}>
+        <p>Object was deleted</p>
+      </div>
+    </>
+  );
+}
+
+export default ConfirmDeleteForm;

--- a/blurp-app/src/components/confirm_delete_form.jsx
+++ b/blurp-app/src/components/confirm_delete_form.jsx
@@ -7,7 +7,9 @@ function ConfirmDeleteForm (props) {
   const HIDDEN_MSG_CLASS = 'obj-deleted-msg opacity-0';
   const VISIBLE_MSG_CLASS = 'obj-deleted-msg';
 
-  const [formClass, setFormClass] = useState(VISIBLE_FORM_CLASS);
+  // The confirm delete form is hidden by default. To see it (for testing purposes),
+  // replace HIDDEN_FORM_CLASS with VISIBLE_FORM_CLASS in the line below.
+  const [formClass, setFormClass] = useState(HIDDEN_FORM_CLASS);
   const [objDeletedMsgClass, setObjDeletedMsgClass] = useState(HIDDEN_MSG_CLASS);
   const form_ref = useRef(null);
 

--- a/blurp-app/src/pages/blurpmap.jsx
+++ b/blurp-app/src/pages/blurpmap.jsx
@@ -15,6 +15,7 @@ import { NodeData, EdgeData } from '../constants/classes.jsx';
 import DataSidebar from '../components/data_sidebar.jsx';
 import GraphToolbar from '../components/graph_toolbar.jsx';
 import System_Toolbar from '../components/system_toolbar.jsx';
+import ConfirmDeleteForm from '../components/confirm_delete_form';
 
 const TestPage = () => {
   const [graph, setGraph] = useState(new MultiGraph());
@@ -184,6 +185,9 @@ const TestPage = () => {
       </div>
       <div className="absolute inset-y-0 top-0 right-0">
         <GraphToolbar />
+      </div>
+      <div className="absolute inset-y-1/2 inset-x-1/2">
+        <ConfirmDeleteForm />
       </div>
     </div>
   );

--- a/blurp-app/src/styles/tailwind.css
+++ b/blurp-app/src/styles/tailwind.css
@@ -94,4 +94,22 @@
   .system-toolbar-button {
     @apply my-[15px] flex h-[40px] justify-center;
   }
+
+  .confirm-delete-form {
+    @apply absolute flex w-[360px] h-[100px] right-[-180px] top-[-50px] rounded-lg bg-gray-200 border border-black border-[2px];
+  }
+
+  .confirm-delete-btn {
+    @apply w-[130px] h-[40px] rounded-lg mx-[10px];
+  }
+  .confirm-delete-btn-yes {
+    @apply confirm-delete-btn bg-white text-red-700 hover:bg-red-700 hover:text-white border border-red-700 border-[2px];
+  }
+  .confirm-delete-btn-no {
+    @apply confirm-delete-btn bg-white text-black hover:bg-black hover:text-white border border-black border-[2px];
+  }
+
+  .obj-deleted-msg {
+    @apply absolute flex w-[180px] h-[30px] right-[-90px] top-[100px] bg-[#f4f466] justify-center items-center border border-black rounded-lg transition transition-all ease-in-out duration-300 pointer-events-none;
+  }
 }


### PR DESCRIPTION
+ Resolves #62: confirm delete UI

The Confirm Delete form is hidden by default. To see it, go to
src/components/confirm_delete_form.jsx  and in line 12 change
HIDDEN_FORM_CLASS to VISIBLE_FORM_CLASS.