### PR TITLE
Timofeys/edge creation

### DIFF
--- a/blurp-app/src/components/confirm_delete_form.jsx
+++ b/blurp-app/src/components/confirm_delete_form.jsx
@@ -21,7 +21,7 @@ function ConfirmDeleteForm (props) {
 
   function delete_clicked() {
     hideForm();
-    tempMsgRef.current.showMessage();
+    tempMsgRef.current.showMessage('Object was deleted');
   }
 
   useEffect(() => {
@@ -52,7 +52,7 @@ function ConfirmDeleteForm (props) {
         </button>
         </div>
       </div>
-      <TempMessage message='Object was deleted' duration={1500} ref={tempMsgRef}></TempMessage>
+      <TempMessage ref={tempMsgRef}></TempMessage>
     </>
   );
 }

--- a/blurp-app/src/components/temp_msg_display.jsx
+++ b/blurp-app/src/components/temp_msg_display.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const HIDDEN_MSG_CLASS = 'obj-deleted-msg opacity-0';
-const VISIBLE_MSG_CLASS = 'obj-deleted-msg opacity-100';
+const HIDDEN_MSG_CLASS = 'temp-msg opacity-0';
+const VISIBLE_MSG_CLASS = 'temp-msg opacity-100';
 
 class TempMessage extends React.Component {
   constructor(props) {

--- a/blurp-app/src/pages/blurpmap.jsx
+++ b/blurp-app/src/pages/blurpmap.jsx
@@ -55,6 +55,8 @@ const TestPage = () => {
   const [pos, setPos] = useState({ x: 0, y: 0 });
   const [sigma, setSigma] = useState(null);
   const [clickTrigger, setClickTrigger] = useState(true);
+  // Tell the user how to create an edge the first time they select the edge tool
+  const [showEdgeMessage, setShowEdgeMessage] = useState(true);
   const child = useRef();
   // const [cookies, setCookie, removeCookie] = useCookies();
   const instance = axios.create({
@@ -476,7 +478,11 @@ const TestPage = () => {
     } else if (data === MAP_TOOLS.edge) {
       setModalTitle('Add Edge');
       setMapToolbar(MAP_TOOLS.edge);
-      msgRef.current.showMessage('Select two nodes to add an edge.');
+      // If this is their first time selecting edge tool, specify how to use
+      if(showEdgeMessage) {
+        msgRef.current.showMessage('Select two nodes to add an edge.');
+        setShowEdgeMessage(false);
+      }
     } else if (data === MAP_TOOLS.eraser) {
       setMapToolbar(MAP_TOOLS.eraser);
     } else {

--- a/blurp-app/src/pages/blurpmap.jsx
+++ b/blurp-app/src/pages/blurpmap.jsx
@@ -42,6 +42,9 @@ const TestPage = () => {
   const [size, setSize] = useState(10);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalTitle, setModalTitle] = useState('Add Node');
+  // When adding an edge, select 2 nodes
+  // const [selectedNode1, setSelectedNode1] = useState(null);
+  // let selectedNode2 = null;
   const [relationship, setRelationship] = useState(Object.keys(RELATIONSHIPS)[0]);
   const [node, setNode] = useState({ selected: new NodeData('', '', '', '', '') });
   const [edge, setEdge] = useState({ selected: new EdgeData('', '', '', '', '', '') });
@@ -437,6 +440,8 @@ const TestPage = () => {
       setMapToolbar(MAP_TOOLS.node);
     } else if (data === MAP_TOOLS.edge) {
       setModalTitle('Add Edge');
+      setNode1(null);
+      setNode2(null);
       setMapToolbar(MAP_TOOLS.edge);
     } else if (data === MAP_TOOLS.eraser) {
       setMapToolbar(MAP_TOOLS.eraser);
@@ -623,12 +628,16 @@ const TestPage = () => {
             } else {
               const grabbed_pos = sigma.viewportToGraph(event);
               setPos({ x: grabbed_pos.x, y: grabbed_pos.y });
-              if (mapToolbar === MAP_TOOLS.node || mapToolbar === MAP_TOOLS.edge) {
-                if (mapToolbar === MAP_TOOLS.edge && graph.order < 2) {
-                  msgRef.current.showMessage('Not enough nodes to add edges to');
-                } else {
-                  setIsModalOpen(true);
-                }
+              // if (mapToolbar === MAP_TOOLS.node || mapToolbar === MAP_TOOLS.edge) {
+              //   if (mapToolbar === MAP_TOOLS.edge && graph.order < 2) {
+              //     msgRef.current.showMessage('Not enough nodes to add edges to');
+              //   } else {
+              //     setIsModalOpen(true);
+              //   }
+              // }
+              if(mapToolbar === MAP_TOOLS.node) {
+                setModalTitle('Add Node');
+                setIsModalOpen(true);
               }
             }
           }
@@ -714,6 +723,32 @@ const TestPage = () => {
             }
             //reenable the click trigger
             setClickTrigger(true);
+          } else if(mapToolbar === MAP_TOOLS.edge) {
+            // This block occurs when the user is in 'edge' mode and clicks
+            // on a node.
+            // Done to clear data and avoid reopening old selections
+            setNode({ selected: new NodeData('', '', '', '', '') });
+            setEdge({ selected: new EdgeData('', '', '', '', '', '') });
+            // If this is the first node selected, simply record this node
+            if(node1 == null) {
+              setNode1(event.node);
+              console.log('first node selected:', event.node);
+            }
+            // Otherwise if this is the second node selected
+            else {
+              // Make sure it's not the same node
+              if(node1 == event.node) {
+                console.log('same node selected');
+              }
+              else {
+                setNode2(event.node);
+                console.log('second node selected');
+                console.log('first node:', node1);
+                console.log('second node:', event.node);
+                setIsModalOpen(true);
+                setModalTitle('Add Edge');
+              }
+            }
           } else {
             // Done to clear data and avoid reopening old selections
             setNode({ selected: new NodeData('', '', '', '', '') });
@@ -880,7 +915,7 @@ const TestPage = () => {
                 {modalTitle === 'Add Edge' && (
                   <div className="relative flex-auto p-6">
                     <div>
-                      <div>
+                      {/* <div>
                         <select
                           className="w-4/5 rounded text-center"
                           value={node1}
@@ -916,7 +951,7 @@ const TestPage = () => {
                               </option>
                             ))}
                         </select>
-                      </div>
+                      </div> */}
                       <br />
                       <div>
                         <select

--- a/blurp-app/src/pages/blurpmap.jsx
+++ b/blurp-app/src/pages/blurpmap.jsx
@@ -33,6 +33,7 @@ import System_Toolbar from '../components/system_toolbar.jsx';
 import ConfirmDeleteForm from '../components/confirm_delete_form';
 import TempMessage from '../components/temp_msg_display';
 import LoadMapModal from '../components/select_map_modal';
+import { capitalize } from '@mui/material';
 
 const TestPage = () => {
   const [graph, setGraph] = useState(new MultiGraph());
@@ -64,7 +65,6 @@ const TestPage = () => {
   });
 
   // Used for the message box that pops up and notifys users of errors
-  const [userNotification, setUserNotification] = useState('');
   const [isSidebarOn, setIsSidebarOn] = useState(false);
   const [mapTitle, setMapTitle] = useState('');
   const msgRef = useRef();
@@ -479,6 +479,7 @@ const TestPage = () => {
     } else if (data === MAP_TOOLS.edge) {
       setModalTitle('Add Edge');
       setMapToolbar(MAP_TOOLS.edge);
+      msgRef.current.showMessage('Select two nodes to add an edge.');
     } else if (data === MAP_TOOLS.eraser) {
       setMapToolbar(MAP_TOOLS.eraser);
     } else {
@@ -544,7 +545,7 @@ const TestPage = () => {
               },
             })
             .then((response) => {
-              msgRef.current.showMessage(mapToolbar + ' was successfully created');
+              msgRef.current.showMessage(capitalize(mapToolbar) + ' was successfully created');
             })
             .catch((error) => {
               if (error.response) {
@@ -565,7 +566,7 @@ const TestPage = () => {
               }
             });
         } else {
-          msgRef.current.showMessage(mapToolbar + ' was successfully created');
+          msgRef.current.showMessage(capitalize(mapToolbar) + ' was successfully created');
         }
       }
     } else {
@@ -611,7 +612,7 @@ const TestPage = () => {
                 },
               })
               .then((response) => {
-                msgRef.current.showMessage(mapToolbar + ' was successfully created');
+                msgRef.current.showMessage(capitalize(mapToolbar) + ' was successfully created');
               })
               .catch((error) => {
                 if (error.response) {
@@ -634,7 +635,7 @@ const TestPage = () => {
                 }
               });
           } else {
-            msgRef.current.showMessage(mapToolbar + ' was successfully created');
+            msgRef.current.showMessage(capitalize(mapToolbar) + ' was successfully created');
           }
         } else {
           // setUserNotification('Edge already exists between those nodes');
@@ -1160,7 +1161,7 @@ const TestPage = () => {
         <MapToolbar handleToolbarEvent={handleToolbarEvent} setSigmaCursor={setSigmaCursor} />
       </div>
       <div className="absolute inset-y-1/2 inset-x-1/2">
-        <TempMessage message={userNotification} ref={msgRef} />
+        <TempMessage ref={msgRef} />
       </div>
       <div className="absolute inset-y-1/2 inset-x-1/2">
         <ConfirmDeleteForm />

--- a/blurp-app/src/pages/blurpmap.jsx
+++ b/blurp-app/src/pages/blurpmap.jsx
@@ -113,6 +113,39 @@ const TestPage = () => {
     });
   };
 
+  // Reset a specific node's color to its default
+  const resetNodeColor = (node) => {
+    let nodeType = graph.getNodeAttributes(node).entity;
+    switch (nodeType) {
+      case NODE_TYPE.PERSON:
+        graph.setNodeAttribute(node, 'color', COLORS.BROWN);
+        break;
+      case NODE_TYPE.PLACE:
+        graph.setNodeAttribute(node, 'color', COLORS.GREY);
+        break;
+      case NODE_TYPE.IDEA:
+        graph.setNodeAttribute(node, 'color', COLORS.OLIVE);
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Reset the two selected nodes' colors
+  const resetNodeColors = () => {
+    if(node1)
+      resetNodeColor(node1);
+    if(node2)
+      resetNodeColor(node2);
+  }
+
+  // Reset edge selection (user may have edges selected, reset)
+  const resetEdgeSelection = () => {
+    setNode1(null);
+    setNode2(null);
+    resetNodeColors();
+  }
+
   const DBref = useRef({
     SaveToDB(mapID) {
       if (profile.profileSet && graph.order > 0) {
@@ -435,13 +468,12 @@ const TestPage = () => {
   }
 
   function handleToolbarEvent(data) {
+    resetEdgeSelection();
     if (data === MAP_TOOLS.node) {
       setModalTitle('Add Node');
       setMapToolbar(MAP_TOOLS.node);
     } else if (data === MAP_TOOLS.edge) {
       setModalTitle('Add Edge');
-      setNode1(null);
-      setNode2(null);
       setMapToolbar(MAP_TOOLS.edge);
     } else if (data === MAP_TOOLS.eraser) {
       setMapToolbar(MAP_TOOLS.eraser);
@@ -459,6 +491,7 @@ const TestPage = () => {
   };
 
   function handleSubmit() {
+    resetEdgeSelection();
     if (mapToolbar === MAP_TOOLS.node && sigma) {
       if (name == '') {
         msgRef.current.showMessage('Need to provide name for the node');
@@ -732,6 +765,7 @@ const TestPage = () => {
             // If this is the first node selected, simply record this node
             if(node1 == null) {
               setNode1(event.node);
+              graph.setNodeAttribute(event.node, 'color', 'yellow');
               console.log('first node selected:', event.node);
             }
             // Otherwise if this is the second node selected
@@ -739,9 +773,12 @@ const TestPage = () => {
               // Make sure it's not the same node
               if(node1 == event.node) {
                 console.log('same node selected');
+                resetNodeColor(event.node);
+                setNode1(null);
               }
               else {
                 setNode2(event.node);
+                graph.setNodeAttribute(event.node, 'color', 'yellow');
                 console.log('second node selected');
                 console.log('first node:', node1);
                 console.log('second node:', event.node);
@@ -1022,7 +1059,11 @@ const TestPage = () => {
                   <button
                     className="background-transparent mr-1 mb-1 px-6 py-2 text-sm font-bold uppercase text-red-500 outline-none transition-all duration-150 ease-linear focus:outline-none"
                     type="button"
-                    onClick={() => setIsModalOpen(false)}>
+                    onClick={() => {
+                      setIsModalOpen(false);
+                      resetEdgeSelection();
+                    }
+                  }>
                     Close
                   </button>
                   <button

--- a/blurp-app/src/pages/blurpmap.jsx
+++ b/blurp-app/src/pages/blurpmap.jsx
@@ -113,23 +113,24 @@ const TestPage = () => {
     });
   };
 
-  // Reset a specific node's color to its default
-  const resetNodeColor = (node) => {
-    let nodeType = graph.getNodeAttributes(node).entity;
+  const nodeTypeToColor = (nodeType) => {
     switch (nodeType) {
       case NODE_TYPE.PERSON:
-        graph.setNodeAttribute(node, 'color', COLORS.BROWN);
-        break;
+        return COLORS.BROWN;
       case NODE_TYPE.PLACE:
-        graph.setNodeAttribute(node, 'color', COLORS.GREY);
-        break;
+        return COLORS.GREY;
       case NODE_TYPE.IDEA:
-        graph.setNodeAttribute(node, 'color', COLORS.OLIVE);
-        break;
+        return COLORS.OLIVE;
       default:
-        break;
+        return COLORS.BROWN;
     }
-  }
+  };
+
+  // Reset a specific node's color to its default
+  const resetNodeColor = (node) => {
+    let nodeType = graph.getNodeAttribute(node, 'entity');
+    graph.setNodeAttribute(node, 'color', nodeTypeToColor(nodeType));
+  };
 
   // Reset the two selected nodes' colors
   const resetNodeColors = () => {
@@ -158,7 +159,8 @@ const TestPage = () => {
                 nodeinfo: {
                   nodeName: attr.label,
                   nodeID: current,
-                  color: attr.color,
+                  // color: attr.color,
+                  color: nodeTypeToColor(attr.entity),
                   size: attr.size,
                   age: attr.years === '' ? 0 : attr.years,
                   type: attr.entity.toLowerCase(),
@@ -250,7 +252,8 @@ const TestPage = () => {
                   size: node.size,
                   years: node.age === 0 ? '' : node.age,
                   notes: node.description,
-                  color: node.color,
+                  // color: node.color,
+                  color: nodeTypeToColor(node.type)
                 });
                 nodeList = nodeList.concat({ id: node.nodeID, label: node.nodeName });
               });
@@ -402,6 +405,7 @@ const TestPage = () => {
    * Triggers the user to download the map JSON as "map.blurp".
    */
   function downloadMapJson() {
+    resetEdgeSelection();
     // Get the JSON data string
     let jsonDataString =
       'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(graph.toJSON()));
@@ -514,7 +518,8 @@ const TestPage = () => {
           size: size,
           years: '',
           notes: '',
-          color: color,
+          // color: color,
+          color: nodeTypeToColor(nodeType),
         });
         setSize(Math.log(2) * 30);
         setNodes(nodes.concat({ id: id, label: name }));
@@ -526,7 +531,8 @@ const TestPage = () => {
               nodeinfo: {
                 nodeName: name,
                 nodeID: id,
-                color: color,
+                // color: color,
+                color: nodeTypeToColor(nodeType),
                 size: size,
                 age: 0,
                 type: nodeType.toLowerCase(),
@@ -989,6 +995,10 @@ const TestPage = () => {
                             ))}
                         </select>
                       </div> */}
+                      <div>
+                        <p>Node 1: <b>{graph.getNodeAttribute(node1, 'label')}</b></p>
+                        <p>Node 2: <b>{graph.getNodeAttribute(node2, 'label')}</b></p>
+                      </div>
                       <br />
                       <div>
                         <select

--- a/blurp-app/src/pages/blurpmap.jsx
+++ b/blurp-app/src/pages/blurpmap.jsx
@@ -783,13 +783,25 @@ const TestPage = () => {
                 setNode1(null);
               }
               else {
-                setNode2(event.node);
-                graph.setNodeAttribute(event.node, 'color', 'yellow');
-                console.log('second node selected');
-                console.log('first node:', node1);
-                console.log('second node:', event.node);
-                setIsModalOpen(true);
-                setModalTitle('Add Edge');
+                // If there's already a node between these two nodes, don't show modal
+                let edgeExists = false;
+                for (const x of graph.edges(node1, event.node)) {
+                  if (x) {
+                    edgeExists = true;
+                  }
+                };
+                if(edgeExists) {
+                  msgRef.current.showMessage('Edge already exists between those nodes');
+                }
+                else {
+                  setNode2(event.node);
+                  graph.setNodeAttribute(event.node, 'color', 'yellow');
+                  console.log('second node selected');
+                  console.log('first node:', node1);
+                  console.log('second node:', event.node);
+                  setIsModalOpen(true);
+                  setModalTitle('Add Edge');
+                }
               }
             }
           } else {

--- a/blurp-app/src/pages/blurpmap.jsx
+++ b/blurp-app/src/pages/blurpmap.jsx
@@ -43,9 +43,6 @@ const TestPage = () => {
   const [size, setSize] = useState(10);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalTitle, setModalTitle] = useState('Add Node');
-  // When adding an edge, select 2 nodes
-  // const [selectedNode1, setSelectedNode1] = useState(null);
-  // let selectedNode2 = null;
   const [relationship, setRelationship] = useState(Object.keys(RELATIONSHIPS)[0]);
   const [node, setNode] = useState({ selected: new NodeData('', '', '', '', '') });
   const [edge, setEdge] = useState({ selected: new EdgeData('', '', '', '', '', '') });
@@ -638,8 +635,7 @@ const TestPage = () => {
             msgRef.current.showMessage(capitalize(mapToolbar) + ' was successfully created');
           }
         } else {
-          // setUserNotification('Edge already exists between those nodes');
-          msgRef.current.showMessage('Edge already exists between those nodes');
+          msgRef.current.showMessage('Edge already exists between these nodes');
         }
       }
     }
@@ -668,13 +664,6 @@ const TestPage = () => {
             } else {
               const grabbed_pos = sigma.viewportToGraph(event);
               setPos({ x: grabbed_pos.x, y: grabbed_pos.y });
-              // if (mapToolbar === MAP_TOOLS.node || mapToolbar === MAP_TOOLS.edge) {
-              //   if (mapToolbar === MAP_TOOLS.edge && graph.order < 2) {
-              //     msgRef.current.showMessage('Not enough nodes to add edges to');
-              //   } else {
-              //     setIsModalOpen(true);
-              //   }
-              // }
               if(mapToolbar === MAP_TOOLS.node) {
                 setModalTitle('Add Node');
                 setIsModalOpen(true);
@@ -773,13 +762,11 @@ const TestPage = () => {
             if(node1 == null) {
               setNode1(event.node);
               graph.setNodeAttribute(event.node, 'color', 'yellow');
-              console.log('first node selected:', event.node);
             }
             // Otherwise if this is the second node selected
             else {
               // Make sure it's not the same node
               if(node1 == event.node) {
-                console.log('same node selected');
                 resetNodeColor(event.node);
                 setNode1(null);
               }
@@ -797,9 +784,6 @@ const TestPage = () => {
                 else {
                   setNode2(event.node);
                   graph.setNodeAttribute(event.node, 'color', 'yellow');
-                  console.log('second node selected');
-                  console.log('first node:', node1);
-                  console.log('second node:', event.node);
                   setIsModalOpen(true);
                   setModalTitle('Add Edge');
                 }
@@ -971,43 +955,6 @@ const TestPage = () => {
                 {modalTitle === 'Add Edge' && (
                   <div className="relative flex-auto p-6">
                     <div>
-                      {/* <div>
-                        <select
-                          className="w-4/5 rounded text-center"
-                          value={node1}
-                          onChange={(e) => {
-                            setNode1(e.target.value);
-                          }}>
-                          <option value="" disabled hidden>
-                            Select Name
-                          </option>
-                          {nodes.map((node) => (
-                            <option key={node.id} value={node.id}>
-                              {node.label}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                      <br />
-                      <div>
-                        <select
-                          value={node2}
-                          className="w-4/5 rounded text-center"
-                          onChange={(e) => {
-                            setNode2(e.target.value);
-                          }}>
-                          <option value="" disabled hidden>
-                            Select Name
-                          </option>
-                          {nodes
-                            .filter((node) => node.id !== node1)
-                            .map((node) => (
-                              <option key={node.id} value={node.id}>
-                                {node.label}
-                              </option>
-                            ))}
-                        </select>
-                      </div> */}
                       <div>
                         <p>Node 1: <b>{graph.getNodeAttribute(node1, 'label')}</b></p>
                         <p>Node 2: <b>{graph.getNodeAttribute(node2, 'label')}</b></p>

--- a/blurp-app/src/styles/tailwind.css
+++ b/blurp-app/src/styles/tailwind.css
@@ -133,8 +133,8 @@
     @apply confirm-delete-btn border border-[2px] border-black bg-white text-black hover:bg-black hover:text-white;
   }
 
-  .obj-deleted-msg {
-    @apply pointer-events-none absolute right-[-90px] top-[100px] flex h-[40px] w-[200px] items-center justify-center rounded-lg border border-black bg-[#f4f466] text-center transition transition-all duration-300 ease-in-out;
+  .temp-msg {
+    @apply pointer-events-none absolute right-[-90px] top-[100px] flex h-fit w-[200px] p-[3px] items-center justify-center rounded-lg border border-black bg-[#f4f466] text-center transition transition-all duration-300 ease-in-out;
   }
 
   .mapTitle { 


### PR DESCRIPTION
Summary: Changed the way edges are added. Made some adjustments to the TempMessage component in the process.

Changes:
* When the user selects the edge tool for the first time, a temp message tells them to select two nodes to add an edge. When a node is selected, its color is temporarily changed to yellow (to emulate selection). The colors are converted back when the user changes tools, unselects a node, is saving to a file (the revert function can be applied to other events too, if needed). When a second node is selected, one of two things happens:
  * If there's already an edge, a temp message tells them there's already an edge
  * If there's no edge, the edge modal is opened. Instead of a dropdown of the nodes, the names of the selected nodes are shown
* When adding nodes or saving the map to the database, the nodes' color is now determined on creation by looking at the node type (as opposed to having a state color variable). This forces the correct node color to be sent to the database even if the node is selected.
* Two temp message changes: size now fits content (to avoid overflow), and fixed weird temp message that popped up when blurp-map was loaded.